### PR TITLE
Fix solr version

### DIFF
--- a/config/conf/solrconfig.xml
+++ b/config/conf/solrconfig.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <config>
-  <luceneMatchVersion>6.3.0</luceneMatchVersion>
+  <luceneMatchVersion>7.3.0</luceneMatchVersion>
   <lib dir="${solr.install.dir:../../../..}/contrib/extraction/lib" regex=".*\.jar" />
   <lib dir="${solr.install.dir:../../../..}/dist/" regex="solr-cell-\d.*\.jar" />
 


### PR DESCRIPTION
``luceneMatchVersion`` should match the version of Solr, ideally that should be picked up from the download Solr version, but as the default is to use Solr 7.3.0 it needs to be updated to that version.