### PR TITLE
Solr releases 4 times a year

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ env:
     - SOLR_VERSION=7.2.1
     - SOLR_VERSION=7.3.0
     - SOLR_VERSION=7.4.0
+    - SOLR_VERSION=7.5.0
+    - SOLR_VERSION=7.6.0
 before_install:
   - mkdir -p $HOME/buildout-cache/{eggs,downloads}
   - virtualenv .


### PR DESCRIPTION
With an open question: do we really need to test every version of the 7.x release line? :sweat_smile: which ones would be relevant? The latest always makes sense, does Solr has some LTS policy of the sorts? :thinking: 