### PR TITLE
feat: use the provided port on buildout

### DIFF
--- a/kitconcept/recipe/solr/__init__.py
+++ b/kitconcept/recipe/solr/__init__.py
@@ -144,7 +144,7 @@ def solr(options):
 
 def solr_start(options):
     subprocess.call(
-        ['./solr', 'start'],
+        ['./solr', 'start', '-p', options['port'], ],
         cwd=options.get('bin-directory') + '/../parts/solr/bin/'
     )
 


### PR DESCRIPTION
Up until now it was completely ignored, regardless of what the README said.